### PR TITLE
fullAutoMode now works as expected in landscape on iPhone Simulator

### DIFF
--- a/ios/Classes/AutoOrientationPlugin.m
+++ b/ios/Classes/AutoOrientationPlugin.m
@@ -8,35 +8,59 @@
             binaryMessenger:[registrar messenger]];
   AutoOrientationPlugin* instance = [[AutoOrientationPlugin alloc] init];
   [registrar addMethodCallDelegate:instance channel:channel];
+
+  [[NSNotificationCenter defaultCenter]
+    addObserver:instance selector:@selector(orientationChanged:)
+    name:UIDeviceOrientationDidChangeNotification
+    object:[UIDevice currentDevice]];
+}
+
+UIDeviceOrientation _realDeviceOrientation = UIDeviceOrientationUnknown;
+bool _ignoreNextChange;
+
+- (void)orientationChanged:(NSNotification *)note
+{
+    if (_ignoreNextChange) {
+        _ignoreNextChange = false;
+        return;
+    }
+    _realDeviceOrientation = [UIDevice currentDevice].orientation;
+}
+
+- (void)forceOrientation:(UIDeviceOrientation)orientation {
+    if (orientation != _realDeviceOrientation) {
+        _ignoreNextChange = true;
+        [[UIDevice currentDevice] setValue:@(orientation) forKey:@"orientation"];
+    }
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     if ([@"setLandscapeRight" isEqualToString:call.method]) {
-        [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationLandscapeRight) forKey:@"orientation"];
+        [self forceOrientation:UIInterfaceOrientationLandscapeRight];
     }
     
     if ([@"setLandscapeLeft" isEqualToString:call.method]) {
-        [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationLandscapeLeft) forKey:@"orientation"];
+        [self forceOrientation:UIInterfaceOrientationLandscapeLeft];
     }
     
     if ([@"setPortraitUp" isEqualToString:call.method]) {
-        [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
+        [self forceOrientation:UIInterfaceOrientationPortrait];
     }
     
     if ([@"setPortraitDown" isEqualToString:call.method]) {
-        [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortraitUpsideDown) forKey:@"orientation"];
+        [self forceOrientation:UIInterfaceOrientationPortraitUpsideDown];
     }
     
     if ([@"setPortraitAuto" isEqualToString:call.method]) {
-        [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
+        [self forceOrientation:UIInterfaceOrientationPortrait];
     }
     
     if ([@"setLandscapeAuto" isEqualToString:call.method]) {
-        [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationLandscapeRight) forKey:@"orientation"];
+        [self forceOrientation:UIInterfaceOrientationLandscapeRight];
     }
     
     if ([@"setAuto" isEqualToString:call.method]) {
-        [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
+        [[UIDevice currentDevice] setValue:@(_realDeviceOrientation) forKey:@"orientation"];
     }
 
     [UIViewController attemptRotationToDeviceOrientation];


### PR DESCRIPTION
Before this change, fullAutoMode always forced portrait mode. This doesn't make sense when the iphone is in landscape and makes the app do a funny dance where it sometimes goes to portrait and back to landscape without the device changing orientation. This change resolves this by maintaining the real device orientation and restoring it when fullAutoMode is pressed.