### PR TITLE
Fix fontVariationSettings not found issue when building release Android builds on Flutter 1.12

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auto_orientation
 description: Set the device orientation programmatically for iOS and Android
-version: 1.0.5
+version: 1.0.6
 author: Sebastian Faujour <sf@bytepark.de>
 homepage: https://github.com/bytepark/auto_orientation
 


### PR DESCRIPTION
Bumped `compileSdkVersion` to `28`.