### PR TITLE
Fix All Modes on iOS

### DIFF
--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -10,6 +10,8 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>UIRequiresFullScreen</key>
+<true/>
 	<key>CFBundleName</key>
 	<string>auto_orientation_example</string>
 	<key>CFBundlePackageType</key>

--- a/ios/Classes/AutoOrientationPlugin.m
+++ b/ios/Classes/AutoOrientationPlugin.m
@@ -36,7 +36,7 @@
     }
     
     if ([@"setAuto" isEqualToString:call.method]) {
-        [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
+        [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationUnknown) forKey:@"orientation"];
     }
 
     [UIViewController attemptRotationToDeviceOrientation];


### PR DESCRIPTION
AutoOrientation.fullAutoMode(); was bugged on iOS and locked to portrait mode. This pull request fixes the issue so full auto works on iOS devices. I also went ahead and added require fullscreen to the info.plist within the example, so the example project functions correctly on iPad.